### PR TITLE
Map dump folder thru docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 var
 node_modules
 data
+dump/db
+dump/admin
+dumpMongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,6 @@ services:
             MONGO_INITDB_ROOT_PASSWORD: secret
         volumes:
             - ./data:/data/db
+            - ./dump:/dump
         ports:
             - 27017:27017


### PR DESCRIPTION
This to allow import/export of measure dumps with :

```sh 

docker exec -it argos_mongo_1 mongorestore --uri="mongodb://root:@localhost:27017" ./dump

docker exec -it argos_mongo_1 mongodump --uri="mongodb://root:@localhost:27017"
```
