### PR TITLE
Fix timing issue

### DIFF
--- a/packages/cli/src/computeMeasureAverage.js
+++ b/packages/cli/src/computeMeasureAverage.js
@@ -7,16 +7,68 @@ const computeMeasureAverage = async measureName => {
 
     const reportCollection = db.collection('report');
 
+    const temp = await measureCollection
+        .aggregate([
+            { $match: { measureName } },
+            {
+                $lookup: {
+                    from: 'measure',
+                    localField: 'time',
+                    foreignField: 'time',
+                    /*let: { containerName2: '$containerName', measureName2: '$measureName', run2: '$run' },
+                    pipeline: [
+                        { $match: { containerName: '$$containerName2', measureName: '$$measureName2', run: '$$run2' } },
+                        { $project: { _id: 0, initialTime: '$time' } },
+                    ],*/
+                    as: 'initialTime',
+                },
+            },
+        ])
+        .toArray();
+
+    console.log('temp', temp);
+
+    /* const temp2 = await measureCollection
+        .aggregate([
+            { $match: { measureName } },
+            {
+                $lookup: {
+                    from: 'measure',
+                    localField: 'run',
+                    foreignField: 'run',
+                    let: { containerName2: '$containerName', measureName2: '$measureName', run2: '$run' },
+                    pipeline: [
+                        { $match: { containerName: '$$containerName2', measureName: '$$measureName2', run: '$$run2' } },
+                        { $project: { _id: 0, initialTime: '$time' } },
+                    ],
+                    as: 'initialTime',
+                },
+            },
+        ])
+        .toArray();
+
+    console.log('temp', temp2); */
+
     const averageMeasures = await measureCollection
         .aggregate([
             { $match: { measureName } },
+            {
+                $lookup: {
+                    from: 'measure',
+                    pipeline: [
+                        { $match: { containerName: '$containerName', measureName: '$measureName', run: '$run' } },
+                        { $project: { _id: 0, initialTime: '$time' } },
+                    ],
+                    as: 'initialTime',
+                },
+            },
             {
                 $project: {
                     measureName: 1,
                     run: 1,
                     containerName: 1,
-                    date: 1,
-                    time: { $round: [{ $divide: ['$time', 1000] }] },
+                    time: { $subtract: ['$time', 2] },
+                    initialTime: '$initialTime',
                     cpu: 1,
                     memory: 1,
                     network: 1,
@@ -24,7 +76,7 @@ const computeMeasureAverage = async measureName => {
             },
             {
                 $group: {
-                    _id: { containerName: '$containerName', time: '$time' },
+                    _id: { containerName: '$containerName', time: '$time', initialTime: '$initialTime' },
                     measureName: { $first: '$measureName' },
 
                     avgCpuPercentage: { $avg: '$cpu.cpuPercentage' },
@@ -50,6 +102,7 @@ const computeMeasureAverage = async measureName => {
                     measureName: 1,
                     containerName: '$_id.containerName',
                     time: '$_id.time',
+                    initialTime: '$_id.initialTime',
                     cpuPercentage: '$avgCpuPercentage',
                     cpuPercentageArea: ['$minCpuPercentage', '$maxCpuPercentage'],
                     memoryUsage: '$avgMemoryUsage',
@@ -62,6 +115,8 @@ const computeMeasureAverage = async measureName => {
             },
         ])
         .toArray();
+
+    //console.log('averageMeasures', averageMeasures);
 
     await reportCollection.insertMany(averageMeasures);
 };

--- a/packages/cli/src/computeMeasureAverage.js
+++ b/packages/cli/src/computeMeasureAverage.js
@@ -93,8 +93,6 @@ const computeMeasureAverage = async measureName => {
         ])
         .toArray();
 
-    //console.log('averageMeasures', averageMeasures);
-
     await reportCollection.insertMany(averageMeasures);
 };
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -16,7 +16,7 @@ const run = async () => {
         console.log(`${lastRun} previous runs detected for measure ${measureName}, adding run to the existing ones.`);
     }
 
-    for (var i = lastRun + 1; i <= lastRun + runQuantity; i++) {
+    for (var i = lastRun + 1; i <= lastRun + parseInt(runQuantity, 10); i++) {
         console.info(`run ${i}:`);
 
         const measuresStoppers = otherContainers.map(getContainerStats(measureName, i));

--- a/packages/cli/src/parseStatsStreamTransform.js
+++ b/packages/cli/src/parseStatsStreamTransform.js
@@ -62,10 +62,6 @@ const parseStatsTransform = (containerName, measureName, run) => {
                     return;
                 }
 
-                if (!startTime) {
-                    startTime = new Date(json.read).getTime();
-                }
-
                 const curAvailableCpu = getCurAvailableCpu(json);
 
                 const preAvailableCpu = getPreAvailableCpu(json);
@@ -108,7 +104,7 @@ const parseStatsTransform = (containerName, measureName, run) => {
                     run,
                     containerName,
                     date: json.read,
-                    time: new Date(json.read).getTime() - startTime,
+                    time: Math.round(new Date(json.read).getTime() / 1000),
                     cpu: {
                         availableCpu,
                         cpuUsage,

--- a/packages/cli/src/parseStatsStreamTransform.js
+++ b/packages/cli/src/parseStatsStreamTransform.js
@@ -49,7 +49,6 @@ const parseStatsTransform = (containerName, measureName, run) => {
     const getCurrentTransmittedNetwork = initGetValueIncrement();
 
     const getPreviousRawIO = initGetPreviousValue();
-    let startTime;
 
     return new stream.Transform({
         transform(chunk, encoding, next) {


### PR DESCRIPTION
Mesure ordinate is wrong because there was an issue in time field computation

Before : 
For each run, store the initial datetime
For each measure, store the current datetime and also the time (time = current datetime minus initial datetime)
But sometimes for some reason, the loop reset and the initial datetime do so.
The the time computed is wrong.

After :
For each mesure, only store the current datetime and a absolute time in seconds 
Then, during agregation, compute the relative time based on the initial measure for each run.

Remaining To do : Succes to write this with mongodb