### PR TITLE
Only call containers that includes the wanted measure

### DIFF
--- a/packages/front/src/App.js
+++ b/packages/front/src/App.js
@@ -19,10 +19,9 @@ const getQueryVariable = variable => {
 };
 
 export const App = () => {
-    const { isLoading, response } = useFetch(`${apiUrl}/containers`);
-    const [globalData, setGlobalData] = useState({});
-
     const measureToTest = getQueryVariable('look') || 'arte_liquid';
+    const { isLoading, response } = useFetch(`${apiUrl}/containers/${measureToTest}`);
+    const [globalData, setGlobalData] = useState({});
 
     const handleSetGlobalData = useCallback(
         (containerName, data) => {

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -11,6 +11,11 @@ const server = new Koa();
 
 const router = new Router();
 
+router.get('/containers/:measure', async ctx => {
+    ctx.body = await reportRepository.getContainersForMeasure(ctx.params.measure);
+    ctx.status = 200;
+});
+
 router.get('/containers', async ctx => {
     ctx.body = await reportRepository.getContainers();
     ctx.status = 200;

--- a/packages/server/src/reportRepository.js
+++ b/packages/server/src/reportRepository.js
@@ -12,6 +12,12 @@ const getContainers = async () => {
     return collection.distinct('containerName');
 };
 
+const getContainersForMeasure = async measure => {
+    const collection = await getReportCollection();
+
+    return collection.distinct('containerName', { measureName: measure });
+};
+
 const getReportForContainer = async containerName => {
     const collection = await getReportCollection();
 
@@ -46,5 +52,6 @@ const getReportForContainer = async containerName => {
 
 module.exports = {
     getContainers,
+    getContainersForMeasure,
     getReportForContainer,
 };


### PR DESCRIPTION
## Issue

Previously, for each display of Argos results, every containers data existing in the db where returned, even if they hadn't to be displayed (if they concerns another measure)

## Solution

Ony call containers data that are linked to the measure currently displayed

Exemple : For `api_platform` measures, don't return also `afed` containers