### PR TITLE
Fix memory measure

### DIFF
--- a/packages/cli/src/computeMeasureAverage.js
+++ b/packages/cli/src/computeMeasureAverage.js
@@ -61,9 +61,9 @@ const computeMeasureAverage = async measureName => {
                     minCpuPercentage: { $min: '$cpu.cpuPercentage' },
                     maxCpuPercentage: { $max: '$cpu.cpuPercentage' },
 
-                    avgMemoryUsage: { $avg: '$memory.usage' },
-                    minMemoryUsage: { $min: '$memory.usage' },
-                    maxMemoryUsage: { $max: '$memory.usage' },
+                    avgMemoryUsage: { $avg: { $subtract: ['$memory.usage', '$memory.cache'] } },
+                    minMemoryUsage: { $min: { $subtract: ['$memory.usage', '$memory.cache'] } },
+                    maxMemoryUsage: { $max: { $subtract: ['$memory.usage', '$memory.cache'] } },
 
                     avgNetworkCurrentReceived: { $avg: '$network.currentReceived' },
                     minNetworkCurrentReceived: { $min: '$network.currentReceived' },

--- a/packages/cli/src/parseStatsStreamTransform.js
+++ b/packages/cli/src/parseStatsStreamTransform.js
@@ -10,6 +10,7 @@ const getOnlineCpus = get(['cpu_stats', 'online_cpus']);
 
 const getMemoryUsage = get(['memory_stats', 'usage']);
 const getMemoryMaxUsage = get(['memory_stats', 'max_usage']);
+const getMemoryStats = get(['memory_stats', 'stats']);
 const getMemoryLimit = get(['memory_stats', 'limit']);
 
 const getReceivedNetwork = get(['networks', 'eth0', 'rx_bytes']);
@@ -98,6 +99,9 @@ const parseStatsTransform = (containerName, measureName, run) => {
                     };
                 }, {});
 
+                const memoryCache = getMemoryStats(json).cache;
+                const memoryRSS = getMemoryStats(json).rss;
+
                 const result = {
                     measureName,
                     run,
@@ -112,6 +116,8 @@ const parseStatsTransform = (containerName, measureName, run) => {
                     memory: {
                         usage: getMemoryUsage(json),
                         maxUsage: getMemoryMaxUsage(json),
+                        cache: memoryCache,
+                        rss: memoryRSS,
                         limit: getMemoryLimit(json),
                     },
                     network: {

--- a/packages/front/src/App.js
+++ b/packages/front/src/App.js
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { css } from 'emotion';
 
 import DetailStats from './DetailStats';
+import DetailMesure from './DetailMesure';
 import GlobalStat from './GlobalStat';
 import { useFetch } from './useFetch';
 import { apiUrl } from './config';
@@ -33,6 +34,12 @@ export const App = () => {
 
     if (isLoading || !response) {
         return '...';
+    }
+
+    const containerToCheck = getQueryVariable('container');
+    const runToCheck = getQueryVariable('run');
+    if (containerToCheck && runToCheck) {
+        return <DetailMesure containerName={containerToCheck} measureToTest={measureToTest} run={runToCheck} />;
     }
 
     return (

--- a/packages/front/src/DetailMesure.js
+++ b/packages/front/src/DetailMesure.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Typography, Card, CardContent } from '@material-ui/core';
+
+import { useFetch } from './useFetch';
+import { apiUrl } from './config';
+
+const DetailMesure = ({ containerName, measureToTest, run }) => {
+    const { isLoading, response } = useFetch(`${apiUrl}/measureRun/${containerName}/${measureToTest}/${run}`);
+
+    if (isLoading || !response) {
+        return '...';
+    }
+
+    return (
+        <CardContainer>
+            <Typography variant="h5">Container : {containerName}</Typography>
+            <Typography variant="h6">
+                Measure : {measureToTest} (run {run})
+            </Typography>
+            <Typography variant="h6">
+                Run {run} ({response.length} entries)
+            </Typography>
+            <textarea rows="50" cols="200">
+                {JSON.stringify(response, null, 1)}
+            </textarea>
+        </CardContainer>
+    );
+};
+
+const CardContainer = ({ children }) => (
+    <Card>
+        <CardContent>{children}</CardContent>
+    </Card>
+);
+
+export default DetailMesure;

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -1,6 +1,7 @@
 const Koa = require('koa');
 const Router = require('koa-router');
 const reportRepository = require('./reportRepository');
+const measureRepository = require('./measureRepository');
 const webpack = require('webpack');
 const koaWebpack = require('koa-webpack');
 const path = require('path');
@@ -18,6 +19,15 @@ router.get('/containers', async ctx => {
 
 router.get('/measure/:containerName', async ctx => {
     ctx.body = await reportRepository.getReportForContainer(ctx.params.containerName);
+    ctx.status = 200;
+});
+
+router.get('/measureRun/:containerName/:measureName/:run', async ctx => {
+    ctx.body = await measureRepository.getMeasureForContainerAndMeasureNameAndRun(
+        ctx.params.containerName,
+        ctx.params.measureName,
+        ctx.params.run,
+    );
     ctx.status = 200;
 });
 

--- a/packages/server/src/measureRepository.js
+++ b/packages/server/src/measureRepository.js
@@ -1,0 +1,20 @@
+const getMongo = require('./getMongo');
+
+const getMeasureCollection = async () => {
+    const mongo = await getMongo();
+
+    return mongo.collection('measure');
+};
+
+const getMeasureForContainerAndMeasureNameAndRun = async (containerName, measureName, run) => {
+    const collection = await getMeasureCollection();
+
+    return collection
+        .find({ containerName: containerName, measureName: measureName, run: parseInt(run, 10) })
+        .sort({ time: 1 })
+        .toArray();
+};
+
+module.exports = {
+    getMeasureForContainerAndMeasureNameAndRun,
+};


### PR DESCRIPTION
Memory usage have to take care of memory cache
I changed memory curve according to this:
https://stackoverflow.com/questions/53764761/inconsistency-between-docker-stats-command-and-docker-rest-api-memory-stats

I also added a debug page to see exact measures values that are saved.
Accessible by using this url format:
http://localhost:3003/?look=memory-test&container=api-platform-argos_cypress_run&run=15

**look** = measure name
**container** = container name
**run** = run id

![image](https://user-images.githubusercontent.com/39904906/91459445-f14f7700-e886-11ea-9f94-d764b9d08d65.png)
